### PR TITLE
Retain debug information in a separate file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,12 +30,17 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
 
 function package() {
     file="$1"
-    strip "$file"
+    if [[ "${PROFILE}" == "release" ]]; then
+        objcopy --only-keep-debug "$file" "$file.debug"
+        objcopy --strip-debug --strip-unneeded "$file"
+        objcopy --add-gnu-debuglink="$file.debug" "$file"
+    fi
     rm "$file.zip" > 2&>/dev/null || true
     # note: would use printf "@ $(basename $file)\n@=bootstrap" | zipnote -w "$file.zip"
     # if not for https://bugs.launchpad.net/ubuntu/+source/zip/+bug/519611
     if [ "$file" != ./bootstrap ] && [ "$file" != bootstrap ]; then
         mv "${file}" bootstrap
+        mv "${file}.debug" bootstrap.debug > 2&>/dev/null || true
     fi
     zip "$file.zip" bootstrap
     rm bootstrap


### PR DESCRIPTION
This is intended to provide a fix for https://github.com/softprops/serverless-rust/issues/49.

The current build script unconditionally invokes `strip` on the build output, which removes all debug information. There are two cases, in which debug information is desirable, however:

 - The binary is built in debug mode. The developer likely intends to have debug information inside the binary. 
 - The binary is built in release mode with debug information enabled. The developer likely intends to build an optimized binary without debug information, but wants debug information in a separate companion file for offline debugging.

With this patch, debug information is retained in dev builds. Note that this makes the resulting binary significantly larger, but is more suitable for testing. In release builds, debug information is moved into `bootstrap.debug` next to `bootstrap.zip`. Developers can use this for debugging.