### PR TITLE
conditionally remove debuginfo from release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ isolate the lambda specific build artifacts from your host-local build artifacts
 
 > **⚠️ Note:** you can switch from the `release` profile to a custom profile like `dev` by providing a `PROFILE` environment variable set to the name of the desired profile. i.e. `-e PROFILE=dev` in your docker run
 
+> **⚠️ Note:** you can include debug symbols in optimized release build binaries by setting `DEBUGINFO`. By default, debug symbols will be stripped from the release binary and set aside in a separate .debug file.
+
 You will want to volume mount `/code` to the directory containing your cargo project.
 
 You can pass additional flags to `cargo`, the Rust build tool, by setting the `CARGO_FLAGS` docker env variable

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 set -eo pipefail
 mkdir -p target/lambda
 export PROFILE=${PROFILE:-release}
+export DEBUGINFO=${DEBUGINFO}
 # cargo uses different names for target
 # of its build profiles
 if [[ "${PROFILE}" == "release" ]]; then
@@ -30,7 +31,7 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
 
 function package() {
     file="$1"
-    if [[ "${PROFILE}" == "release" ]]; then
+    if [[ "${PROFILE}" == "release" ]] && [[ -z "${DEBUGINFO}" ]]; then
         objcopy --only-keep-debug "$file" "$file.debug"
         objcopy --strip-debug --strip-unneeded "$file"
         objcopy --add-gnu-debuglink="$file.debug" "$file"


### PR DESCRIPTION
This patch adds an environment variable `DEBUGINFO`, which when set will
prevent the build script from stripping the debug symbols from the
binary. Doing so allows for release builds which include debug symbols
but are otherwise optimized.