### PR TITLE
Build volume support (speed up use on Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ $ docker run --rm \
     softprops/lambda-rust
 ```
 
+If you're suffering from poor performance on Windows, you can enable a separate build volume
+to speed up file access. Initial setup requires creating a docker volume with the following command.
+```sh
+$ docker volume create rust-build-volume
+```
+Now you can run the build with the following command and both clean and incremental builds
+should be way faster.
+```sh
+$ docker run --rm \
+    -e BIN={your-binary-name} \
+    -v ${PWD}:/code \
+    -v rust-build-volume:/build-volume \
+    softprops/lambda-rust
+```
+
 ## 🤸🤸 usage via cargo aws-lambda subcommand
 
 If you want to set up ad hoc lambda functions or have another reason to not to go with full blown devops orchestration tools,
@@ -69,6 +84,8 @@ To compile and deploy in your project directory
 ```sh
 $ cargo aws-lambda {your aws function's full ARN} {your-binary-name}
 ```
+
+> 💡 Add `--use-build-volume` to get speed up on Windows
 
 To list all options 
 ```sh


### PR DESCRIPTION
On Windows 10 my personal project with a total of 325 crates takes **12m 39s** to do a clean release build (host registry mapped to the container as per README). Relocating the registry and build directory to a pristine docker volume using feature introduced in this PR, it now takes **4m 58s** to do a clean release build. And this is including downloading the crates unlike in the former case.

In fact, doing a release build on the host without docker in the picture, it takes **5m 40s**, which is almost a minute slower than in docker.

How this works is that it checks, if there exists a path `/build-volume` in the container and uses it, if it does. It doesn't affect the default operation otherwise.