### PR TITLE
Keep bootstrap binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/lambci/docker-lambda#documentation
 FROM lambci/lambda:build-provided
-ARG RUST_VERSION
+ARG RUST_VERSION=stable
 RUN yum install -y jq
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
  | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Hooks are just shell scripts that are invoked in a specific order, so you can cu
 * `build`: run after `cargo build`, but before packaging the executable into a zip - useful when modifying the executable after compilation
 * `package`: run after packaging the executable into a zip - useful for adding extra files into the zip file
 
-The hooks' names are predefined and must be placed in a directory `.lambda-rust` in the project root. 
+The hooks' names are predefined and must be placed in a directory `.lambda-rust` in the project root.
 
 You can take a look at an example [here](./tests/test-func-with-hooks).
 
@@ -144,7 +144,7 @@ To compile and deploy in your project directory
 $ cargo aws-lambda {your aws function's full ARN} {your-binary-name}
 ```
 
-To list all options 
+To list all options
 ```sh
 $ cargo aws-lambda --help
 ```

--- a/README.md
+++ b/README.md
@@ -79,13 +79,10 @@ You can invoke this bootstap executable with the lambda-ci docker image for the 
 ```sh
 # start a one-off docker container replicating the "provided" lambda runtime
 # awaiting an event to be provided via stdin
-$ unzip -o \
-    target/lambda/release/{your-binary-name}.zip \
-    -d /tmp/lambda && \
-  docker run \
+$ docker run \
     -i -e DOCKER_LAMBDA_USE_STDIN=1 \
     --rm \
-    -v /tmp/lambda:/var/task:ro,delegated \
+    -v ${PWD}/target/lambda/release:/var/task:ro,delegated \
     lambci/lambda:provided
 
 # provide an event payload via stdin (typically a json blob)

--- a/build.sh
+++ b/build.sh
@@ -49,20 +49,18 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
 
 function package() {
     file="$1"
+    OUTPUT_FOLDER="output"
     if [[ "${PROFILE}" == "release" ]] && [[ -z "${DEBUGINFO}" ]]; then
         objcopy --only-keep-debug "$file" "$file.debug"
         objcopy --strip-debug --strip-unneeded "$file"
         objcopy --add-gnu-debuglink="$file.debug" "$file"
     fi
     rm "$file.zip" > 2&>/dev/null || true
-    # note: would use printf "@ $(basename $file)\n@=bootstrap" | zipnote -w "$file.zip"
-    # if not for https://bugs.launchpad.net/ubuntu/+source/zip/+bug/519611
-    if [ "$file" != ./bootstrap ] && [ "$file" != bootstrap ]; then
-        mv "${file}" bootstrap
-        mv "${file}.debug" bootstrap.debug > 2&>/dev/null || true
-    fi
-    zip "$file.zip" bootstrap
-    rm bootstrap
+    rm -r "${OUTPUT_FOLDER}" > 2&>/dev/null || true
+    mkdir "${OUTPUT_FOLDER}"
+    cp "${file}" "${OUTPUT_FOLDER}/bootstrap"
+    cp "${file}.debug" "${OUTPUT_FOLDER}/bootstrap.debug" > 2&>/dev/null || true
+    zip -j "$file.zip" "${OUTPUT_FOLDER}/bootstrap"
 
     if test -f "$HOOKS_DIR/$PACKAGE_HOOK"; then
         echo "Running package hook"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,6 +4,7 @@
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Root directory of the repository
 DIST=$(cd "$HERE"/..; pwd)
+IMAGE=${1:-softprops/lambda-rust}
 
 source "${HERE}"/bashtest.sh
 
@@ -15,7 +16,7 @@ package_bin() {
     -v "${PWD}":/code \
     -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
     -v "${HOME}"/.cargo/git:/root/.cargo/git \
-    softprops/lambda-rust && \
+    ${IMAGE} && \
     ls target/lambda/release/"$1".zip > /dev/null 2>&1
 }
 
@@ -26,7 +27,7 @@ package_all() {
     -v "${PWD}":/code \
     -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
     -v "${HOME}"/.cargo/git:/root/.cargo/git \
-    softprops/lambda-rust && \
+    ${IMAGE} && \
     ls target/lambda/release/"${1}".zip > /dev/null 2>&1
 }
 
@@ -38,13 +39,13 @@ package_all_dev_profile() {
     -v "${PWD}":/code \
     -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
     -v "${HOME}"/.cargo/git:/root/.cargo/git \
-    softprops/lambda-rust && \
+    ${IMAGE} && \
     ls target/lambda/debug/"${1}".zip > /dev/null 2>&1
 }
 
 for project in test-func test-multi-func test-func-with-hooks; do
     cd "${HERE}"/"${project}"
-    echo "👩‍🔬 Running tests for $project"
+    echo "👩‍🔬 Running tests for $project with image $IMAGE"
 
     if [[ "$project" == test-multi-func ]]; then
         bin_name=test-func


### PR DESCRIPTION
This is convenient for local testing because one can skip the unzipping step before using the `lambci/lambda` image.
