### PR TITLE
Run build.sh as a normal user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM lambci/lambda:build-provided
 ARG RUST_VERSION
 RUN yum install -y jq
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
- | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
+ | CARGO_HOME=/cargo RUSTUP_HOME=/cargo sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 ADD build.sh /usr/local/bin/
 VOLUME ["/code"]
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ A typical docker run might look like the following.
 ```sh
 $ docker run --rm \
     -v ${PWD}:/code \
-    -v ${HOME}/.cargo/registry:/root/.cargo/registry \
-    -v ${HOME}/.cargo/git:/root/.cargo/git \
+    -u $(id -u):$(id -g) \
+    -v ${HOME}/.cargo/registry:/cargo/registry \
+    -v ${HOME}/.cargo/git:/cargo/git \
     softprops/lambda-rust
 ```
 
-> 💡 The -v (volume mount) flags for `/root/.cargo/{registry,git}` are optional but when supplied, provides a much faster turn around when doing iterative development
+> 💡 The -v (volume mount) flags for `/cargo/{registry,git}` are optional but when supplied, provides a much faster turn around when doing iterative development
 
 If you are using Windows, the command above may need to be modified to include
 a `BIN` environment variable set to the name of the binary to be build and packaged
@@ -51,8 +52,8 @@ a `BIN` environment variable set to the name of the binary to be build and packa
 $ docker run --rm \
     -e BIN={your-binary-name} \
     -v ${PWD}:/code \
-    -v ${HOME}/.cargo/registry:/root/.cargo/registry \
-    -v ${HOME}/.cargo/git:/root/.cargo/git \
+    -v ${HOME}/.cargo/registry:/cargo/registry \
+    -v ${HOME}/.cargo/git:/cargo/git \
     softprops/lambda-rust
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,8 @@ set -eo pipefail
 mkdir -p target/lambda
 export PROFILE=${PROFILE:-release}
 export DEBUGINFO=${DEBUGINFO}
+export CARGO_HOME="/cargo"
+export RUSTUP_HOME="/cargo"
 # cargo uses different names for target
 # of its build profiles
 if [[ "${PROFILE}" == "release" ]]; then
@@ -31,7 +33,7 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
     fi
 
     # source cargo
-    . $HOME/.cargo/env
+    . $CARGO_HOME/env
     # cargo only supports --release flag for release
     # profiles. dev is implicit
     if [ "${PROFILE}" == "release" ]; then
@@ -73,7 +75,7 @@ function package() {
 
 cd "${CARGO_TARGET_DIR}/${TARGET_PROFILE}"
 (
-    . $HOME/.cargo/env
+    . $CARGO_HOME/env
     if [ -z "$BIN" ]; then
         IFS=$'\n'
         for executable in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .targets[] | select(.kind[] | contains("bin")) | .name'); do

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,10 +11,11 @@ source "${HERE}"/bashtest.sh
 package_bin() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e BIN="$1" \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     softprops/lambda-rust && \
     ls target/lambda/release/"$1".zip > /dev/null 2>&1
 }
@@ -23,9 +24,10 @@ package_bin() {
 package_all() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     softprops/lambda-rust && \
     ls target/lambda/release/"${1}".zip > /dev/null 2>&1
 }
@@ -34,10 +36,11 @@ package_all() {
 package_all_dev_profile() {
     rm -rf target/lambda/debug > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e PROFILE=dev \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     softprops/lambda-rust && \
     ls target/lambda/debug/"${1}".zip > /dev/null 2>&1
 }


### PR DESCRIPTION
The docker container runs as `root` so mounting `registry` and `git` in the container results in pollution of a users `.cargo` folder with `root`-owned artifacts. Trying to do things like `cargo update` will then break.

Instead run the container as a normal user.

Requires pulling the cargo install out of `/root`. Also the `yum install` step won't work when running as a normal user. When run in the test suite the container will recompile the project even though it doesn't have to (I haven't figured out why, when I `docker run` by hand in the test folder it works as expected (finishes compilation in less than a second because its already done).

Note: this will still write ~/.cargo/registry and ~/.cargo/git as
owned by root if they don't exist when the container runs. May be
due to -v mounts ignoring -u when the mountpoint doesn't exist.