### PR TITLE
Compile only the specified $BIN binary if it is passed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,12 +32,15 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
 
     # source cargo
     . $HOME/.cargo/env
+
+    CARGO_BIN_ARG="" && [[ -n "$BIN" ]] && CARGO_BIN_ARG="--bin ${BIN}"
+
     # cargo only supports --release flag for release
     # profiles. dev is implicit
     if [ "${PROFILE}" == "release" ]; then
-        cargo build ${CARGO_FLAGS:-} --${PROFILE}
+        cargo build ${CARGO_BIN_ARG} ${CARGO_FLAGS:-} --${PROFILE}
     else
-        cargo build ${CARGO_FLAGS:-}
+        cargo build ${CARGO_BIN_ARG} ${CARGO_FLAGS:-}
     fi
 
     if test -f "$HOOKS_DIR/$BUILD_HOOK"; then


### PR DESCRIPTION
In my case I have a huge cargo workspace, some of its crates use platform-specific build scripts and dependencies and that are (A) very long to compile and (B) are impossible to compile using raw `lambci` image due to the lack of some `C` libraries.

My solution is to pass `--bin $BIN` flag to `cargo build` to prevent it from building the entire workspace and just compile only the crate with the lambda if `$BIN` is not an empty string.

As my current temporary workaround for this, I use to pass both options `BIN=<lambda_binary_name> CARGO_FLAGS=--bin <lambda_binary_name>`, which is not horrible, but a bit inconvenient in terms of violating DRY.
Anyway, I'd like to upstream the behaviour I proposed
