### PR TITLE
Fix rm waiting for stdin (interactive mode) in tests

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -61,8 +61,8 @@ for project in test-func test-multi-func test-func-with-hooks; do
     assert "it packages all bins" package_all "${bin_name}"
 
     # verify packaged artifact by invoking it using the lambdaci "provided" docker image
-    rm output.log > /dev/null 2>&1
-    rm test-out.log > /dev/null 2>&1
+    rm -f output.log > /dev/null 2>&1
+    rm -f test-out.log > /dev/null 2>&1
     rm -rf /tmp/lambda > /dev/null 2>&1
     unzip -o  \
         target/lambda/release/"${bin_name}".zip \


### PR DESCRIPTION
I can confirm that the problem with tests timing out is that `rm` is waiting for confirmation from stdin in interactive mode. (https://github.com/softprops/lambda-rust/pull/68#issuecomment-650205704)
![image](https://user-images.githubusercontent.com/36276403/86119025-69ddc580-bada-11ea-92be-f13450a1d6ad.png)
`-f` flag should tackle this.