### PR TITLE
Run the builds as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM lambci/lambda:build-provided
 ARG RUST_VERSION=stable
 RUN yum install -y jq
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
- | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
+ | CARGO_HOME=/cargo RUSTUP_HOME=/rustup sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 ADD build.sh /usr/local/bin/
 VOLUME ["/code"]
 WORKDIR /code

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ test: build
 
 debug: build
 	@docker run --rm -it \
+		-u $(id -u):$(id -g) \
 		-v ${PWD}:/code \
-		-v ${HOME}/.cargo/registry:/root/.cargo/registry \
-		-v ${HOME}/.cargo/git:/root/.cargo/git  \
+		-v ${HOME}/.cargo/registry:/cargo/registry \
+		-v ${HOME}/.cargo/git:/cargo/git  \
 		--entrypoint=/bin/bash \
 		$(REPO)

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,9 @@ mkdir -p target/lambda
 export PROFILE=${PROFILE:-release}
 export PACKAGE=${PACKAGE:-true}
 export DEBUGINFO=${DEBUGINFO}
+export CARGO_HOME="/cargo"
+export RUSTUP_HOME="/rustup"
+
 # cargo uses different names for target
 # of its build profiles
 if [[ "${PROFILE}" == "release" ]]; then
@@ -32,7 +35,7 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
     fi
 
     # source cargo
-    . $HOME/.cargo/env
+    . $CARGO_HOME/env
 
     CARGO_BIN_ARG="" && [[ -n "$BIN" ]] && CARGO_BIN_ARG="--bin ${BIN}"
 
@@ -77,7 +80,7 @@ function package() {
 
 cd "${CARGO_TARGET_DIR}/${TARGET_PROFILE}"
 (
-    . $HOME/.cargo/env
+    . $CARGO_HOME/env
     if [ -z "$BIN" ]; then
         IFS=$'\n'
         for executable in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .targets[] | select(.kind[] | contains("bin")) | .name'); do

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,10 +12,11 @@ source "${HERE}"/bashtest.sh
 package_bin() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e BIN="$1" \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} && \
     ls target/lambda/release/"${1}".zip > /dev/null 2>&1 &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -26,9 +27,10 @@ package_bin() {
 package_all() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} && \
     ls target/lambda/release/"${1}".zip > /dev/null 2>&1 &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -39,10 +41,11 @@ package_all() {
 compile_without_packaging() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e PACKAGE=false \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} &&
     !(ls target/lambda/release/"${1}".zip > /dev/null 2>&1) &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -53,10 +56,11 @@ compile_without_packaging() {
 package_all_dev_profile() {
     rm -rf target/lambda/debug > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e PROFILE=dev \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} && \
     ls target/lambda/debug/"${1}".zip > /dev/null 2>&1 &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -86,7 +90,7 @@ for project in test-func test-multi-func test-func-with-hooks; do
     rm -f output.log > /dev/null 2>&1
     rm -f test-out.log > /dev/null 2>&1
     rm -rf /tmp/lambda > /dev/null 2>&1
-    unzip -o  \
+    unzip -o \
         target/lambda/release/"${bin_name}".zip \
         -d /tmp/lambda > /dev/null 2>&1 && \
     docker run \


### PR DESCRIPTION
This is basically the resurrection of https://github.com/softprops/lambda-rust/pull/62
Closes #62

Thanks for the investigation to @medwards, there indeed is a bug in tests right now on master, because this ends with an error:
```bash
rm -rf target/lambda/release > /dev/null 2>&1
```
If you remove `> /dev/null 2>&1` part, you will see it:
```
error: failed to open: /code/target/lambda/release/.cargo-lock

Caused by:
  Permission denied (os error 13)
👎   it compiles the binaries without zipping when PACKAGE=false: fail
```

whilst it is expected that tests do clean the target dir, but since the `target/lambda` dir is owned by docker `root` user this doesn't happen and repeated tests don't do the full recompilation.

With this commit, which is copied from https://github.com/softprops/lambda-rust/pull/62 with small changes (e.g. `RUSTUP_HOME=/rustup` instead of  `RUSTUP_HOME=/cargo`) the bug has to be resolved and the problem with poisoning the host with artifacts which are owned by `root` must be gone.

However, the following is still an open problem:
> Note: this will still write ~/.cargo/registry and ~/.cargo/git as
owned by root if they don't exist when the container runs. May be
due to -v mounts ignoring -u when the mountpoint doesn't exist.

But I think we might still merge this as it is since that problem is not a trivial one and the users 99% of the time will already have the cargo home available, however, I did add a note on that caveat to `README.md`

cc @softprops 