### PR TITLE
Publish update for Rust 1.51.0 to dockerhub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0-rust-1.51.0
+
+* Update to Rust [`1.51.0`](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html)
+
 # 0.4.0-rust-1.45.2
 
 * **Breaking change** in avoid mixed user permissions when volume mounting cargo cache directories. This docker images now configures a cargo installation to `/cargo` directory rather than `/home/root/.cargo`. You'll also want to ensure


### PR DESCRIPTION
I was trying to use this package (via the serverless plugin) the other day, and ran into issues building socket2. Stepping through the problem, I realized that the [Dockerhub image hasn't been updated in 9 months](https://hub.docker.com/r/softprops/lambda-rust/tags?page=1&ordering=last_updated). Specifically, [this tag](https://github.com/softprops/lambda-rust/releases/tag/v0.3.0-rust-1.45.0) is the last version in Dockerhub.

Would it be possible to get this commit tagged appropriately so GH actions publishes it through to Dockerhub? 